### PR TITLE
fixed typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha test -R spec -s 1700 -t 20000"
   },
-  "repositories": {
+  "repository": {
     "type":"git",
     "url":"https://github.com/silentrob/superscript"
   },


### PR DESCRIPTION
npm doesn't like it that way:

```
npm WARN package.json superscript@0.1.8 'repositories' (plural) Not supported. Please pick one as the 'repository' field
npm WARN package.json superscript@0.1.8 No repository field.
```
