### PR TITLE
Updates test fixtures for newline wrapping

### DIFF
--- a/test/fixtures/script/script.ss
+++ b/test/fixtures/script/script.ss
@@ -240,10 +240,10 @@
 
 // Test Multiple line output
 + tell me a poem
-- Little Miss Muffit sat on her tuffet,\n
-^ In a nonchalant sort of way.\n
-^ With her forcefield around her,\n
-^ The Spider, the bounder,\n
+- Little Miss Muffit sat on her tuffet,
+^ In a nonchalant sort of way.
+^ With her forcefield around her,
+^ The Spider, the bounder,
 ^ Is not in the picture today.
 
 
@@ -265,11 +265,11 @@
 // Sub Replies
 // These are returned as seperate messages in reply to a single gambit.
 + what color is a rainbow
-- red\n
-^ {delay=500} orange\n
-^ {delay=500} yellow\n
-^ {delay=500} green\n
-^ {delay=500} blue\n
+- red
+^ {delay=500} orange
+^ {delay=500} yellow
+^ {delay=500} green
+^ {delay=500} blue
 ^ {delay=500} and black?
 
 + how many colors in the rainbow


### PR DESCRIPTION
This is related to the ss-parser pull request: https://github.com/silentrob/ss-parser/pull/2

Since the tests for `Multiple line output` in SuperScript cover this case and expect the fixtures to explicitly contain `\n` in order to get a newline back, the only modification needed was in the fixtures where the `\n` was removed. The `ss-parser` with the update from the above pull request was used to confirm the tests.
