### PR TITLE
get models out of global namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ botfacts
 dump.rdb
 dump/*
 coverage
+*.sw*

--- a/lib/topics/common.js
+++ b/lib/topics/common.js
@@ -1,5 +1,3 @@
-/* global Reply, Gambit, Topic */
-
 // These are shared helpers for the models.
 
 var async = require("async");
@@ -8,281 +6,289 @@ var regexreply = require("ss-parser/lib/regexreply");
 var Utils = require("../utils");
 var _ = require("lodash");
 
-var _walkReplyParent = function (repId, replyIds, cb) {
-  Reply.findById(repId)
-    .populate("parent")
-    .exec(function (err, reply) {
-      if (err) {
-        debug.error(err);
-      }
+module.exports = function(mongoose) {
+    var getReply = function() { return mongoose.model('Reply'); }
+      , getGambit = function() { return mongoose.model('Gambit'); }
+      , getCondition = function() { return mongoose.model('Condition'); }
+      , getTopic = function() { return mongoose.model('Topic'); }
+    ;
+
+    var _walkReplyParent = function (repId, replyIds, cb) {
+        getReply().findById(repId)
+        .populate("parent")
+        .exec(function (err, reply) {
+            if (err) {
+                debug.error(err);
+            }
 
 
-      debug.info("Walk", reply);
+            debug.info("Walk", reply);
 
-      if (reply) {
-        replyIds.push(reply._id);
+            if (reply) {
+                replyIds.push(reply._id);
 
-        if (reply.parent && reply.parent.parent) {
-          _walkReplyParent(reply.parent.parent, replyIds, cb);
-        } else {
-          cb(null, replyIds);
-        }
-      } else {
-        cb(null, replyIds);
-      }
-    });
-};
-
-exports.walkReplyParent = function (repId, cb) {
-  _walkReplyParent(repId, [], cb);
-};
-
-
-var _walkGambitParent = function (gambitId, gambitIds, cb) {
-  Gambit.findOne({_id: gambitId})
-    .populate("parent")
-    .exec(function (err, gambit) {
-      if (err) {
-        console.log(err);
-      }
-
-      if (gambit) {
-        gambitIds.push(gambit._id);
-        if (gambit.parent && gambit.parent.parent) {
-          _walkGambitParent(gambit.parent.parent, gambitIds, cb);
-        } else {
-          cb(null, gambitIds);
-        }
-      } else {
-        cb(null, gambitIds);
-      }
-    });
-};
-
-exports.walkGambitParent = function (gambitId, cb) {
-  _walkGambitParent(gambitId, [], cb);
-};
-
-
-// This will find all the gambits to process by parent (topic or conversation)
-exports.eachGambit = function (type, id, options, callback) {
-  // Lets Query for Gambits
-
-  var execHandle = function (err, mgambits) {
-
-    if (err) {
-      console.log(err);
-    }
-
-    var populateGambits = function (gambit, cb) {
-      Reply.populate(gambit, {path: "replies"}, cb);
+                if (reply.parent && reply.parent.parent) {
+                    _walkReplyParent(reply.parent.parent, replyIds, cb);
+                } else {
+                    cb(null, replyIds);
+                }
+            } else {
+                cb(null, replyIds);
+            }
+        });
     };
 
-    async.each(mgambits.gambits, populateGambits, function populateGambitsComplete(err2) {
-      if (err2) {
-        console.log(err2);
-      }
-      async.map(mgambits.gambits, _eachGambitHandle(options),
-        function eachGambitHandleComplete(err3, matches) {
-          callback(null, _.flatten(matches));
-        }
-      );
-    });
-  };
-
-  if (type === "topic") {
-    debug.verbose("Looking back Topic", id);
-    Topic.findOne({_id: id}, "gambits")
-      .populate({path: "gambits", match: {isCondition: false }})
-      .exec(execHandle);
-  } else if (type === "reply") {
-    debug.verbose("Looking back at Conversation", id);
-    Reply.findOne({_id: id}, "gambits")
-      .populate({path: "gambits", match: {isCondition: false }})
-      .exec(execHandle);
-  } else if (type === "condition") {
-    debug.verbose("Looking back at Conditions", id);
-    Condition.findOne({_id: id}, "gambits")
-      .populate("gambits")
-      .exec(execHandle);
-  } else {
-    debug.verbose("We should never get here");
-    callback(true);
-  }
-};
-
-var _afterHandle = function (match, matches, trigger, topic, cb) {
-  debug.verbose("Match found", trigger, match);
-  debug.info("Match found '" + trigger.input + "' in topic '" + topic + "'");
-  var stars = [];
-  if (match.length > 1) {
-    for (var j = 1; j < match.length; j++) {
-      if (match[j]) {
-        var starData = Utils.trim(match[j]);
-        // Concepts are not allowed to be stars or captured input.
-        starData = (starData[0] == "~") ? starData.substr(1) : starData;
-        stars.push(starData);
-      }
-    }
-  }
-
-  var data = {stars: stars, trigger: trigger };
-  if (topic !== "reply") {
-    data.topic = topic;
-  }
-
-  matches.push(data);
-  cb(null, matches);
-};
-
-var _doesMatch = function(trigger, message, user, callback) {
-
-  var match = false;
-
-  regexreply.postParse(trigger.trigger, message, user, function complexFunction(regexp) {
-    var pattern = new RegExp("^" + regexp + "$", "i");
-
-    debug.verbose("Try to match (clean)'" + message.clean + "' against " + trigger.trigger + " (" + regexp + ")");
-    debug.verbose("Try to match (lemma)'" + message.lemString + "' against " + trigger.trigger + " (" + regexp + ")");
-
-    // Match on the question type (qtype / qsubtype)
-    if (trigger.isQuestion && message.isQuestion) {
-
-      if (_.isEmpty(trigger.qSubType) && _.isEmpty(trigger.qType) && message.isQuestion === true) {
-        match = message.clean.match(pattern);
-        if (!match) {
-          match = message.lemString.match(pattern);
-        }
-      } else {
-        if ((!_.isEmpty(trigger.qType) && message.qtype.indexOf(trigger.qType) !== -1) ||
-          message.qSubType === trigger.qSubType) {
-          match = message.clean.match(pattern);
-          if (!match) {
-            match = message.lemString.match(pattern);
-          }
-        }
-      }
-    } else {
-      // This is a normal match
-      if (trigger.isQuestion === false) {
-        match = message.clean.match(pattern);
-        if (!match) {
-          match = message.lemString.match(pattern);
-        }
-      }
-    }
-
-    callback(null, match);
-  });
-};
-
-exports.doesMatch = _doesMatch;
-
-// This is the main function that looks for a matching entry
-var _eachGambitHandle = function (options) {
-  var filterRegex = /\s*\^(\w+)\(([\w<>,\|\s]*)\)\s*/i;
-
-  return function (trigger, callback) {
-
-    var match = false;
-    var matches = [];
-
-    var message = options.message;
-    var user = options.user;
-    var plugins = options.plugins;
-    var scope = options.scope;
-    var topic = options.topic || "reply";
-
-    _doesMatch(trigger, message, user, function (err, match) {
-
-      if (match) {
-        if (trigger.filter !== "") {
-          // We need scope and functions
-          debug.verbose("We have a filter function", trigger.filter);
-
-          var filterFunction = trigger.filter.match(filterRegex);
-          debug.verbose("Filter Function Found", filterFunction);
-
-          var pluginName = Utils.trim(filterFunction[1]);
-          var partsStr = Utils.trim(filterFunction[2]);
-          var parts = partsStr.split(",");
-
-          var args = [];
-          for (var i = 0; i < parts.length; i++) {
-            if (parts[i] !== "") {
-              args.push(parts[i].trim());
-            }
-          }
-
-          if (plugins[pluginName]) {
-
-            var filterScope = scope;
-            filterScope.message = options.localOptions.message;
-            filterScope.message_props = options.localOptions.messageScope;
-            filterScope.user = options.localOptions.user;
-
-            args.push(function customFilterFunctionHandle(err, filterReply) {
-              if (err) {
+    var _walkGambitParent = function (gambitId, gambitIds, cb) {
+        getGambit().findOne({_id: gambitId})
+        .populate("parent")
+        .exec(function (err, gambit) {
+            if (err) {
                 console.log(err);
-              }
+            }
 
-              if (filterReply === "true" || filterReply === true) {
-                debug.verbose("filterReply", filterReply);
+            if (gambit) {
+                gambitIds.push(gambit._id);
+                if (gambit.parent && gambit.parent.parent) {
+                    _walkGambitParent(gambit.parent.parent, gambitIds, cb);
+                } else {
+                    cb(null, gambitIds);
+                }
+            } else {
+                cb(null, gambitIds);
+            }
+        });
+    };
 
-                if (trigger.redirect !== "") {
-                  debug.verbose("Found Redirect Match with topic " + topic);
-                  Topic.findTriggerByTrigger(trigger.redirect, function (err2, gambit) {
-                    if (err2) {
-                      console.log(err2);
+    // This will find all the gambits to process by parent (topic or conversation)
+    var eachGambit = function (type, id, options, callback) {
+        // Lets Query for Gambits
+
+        var execHandle = function (err, mgambits) {
+
+            if (err) {
+                console.log(err);
+            }
+
+            var populateGambits = function (gambit, cb) {
+                getReply().populate(gambit, {path: "replies"}, cb);
+            };
+
+            async.each(mgambits.gambits, populateGambits, function populateGambitsComplete(err2) {
+                if (err2) {
+                    console.log(err2);
+                }
+                async.map(mgambits.gambits, _eachGambitHandle(options),
+                function eachGambitHandleComplete(err3, matches) {
+                    callback(null, _.flatten(matches));
+                }
+                );
+            });
+        };
+
+        if (type === "topic") {
+            debug.verbose("Looking back Topic", id);
+            getTopic().findOne({_id: id}, "gambits")
+            .populate({path: "gambits", match: {isCondition: false }})
+            .exec(execHandle);
+        } else if (type === "reply") {
+            debug.verbose("Looking back at Conversation", id);
+            getReply().findOne({_id: id}, "gambits")
+            .populate({path: "gambits", match: {isCondition: false }})
+            .exec(execHandle);
+        } else if (type === "condition") {
+            debug.verbose("Looking back at Conditions", id);
+            getCondition().findOne({_id: id}, "gambits")
+            .populate("gambits")
+            .exec(execHandle);
+        } else {
+            debug.verbose("We should never get here");
+            callback(true);
+        }
+    };
+
+    var _afterHandle = function (match, matches, trigger, topic, cb) {
+        debug.verbose("Match found", trigger, match);
+        debug.info("Match found '" + trigger.input + "' in topic '" + topic + "'");
+        var stars = [];
+        if (match.length > 1) {
+            for (var j = 1; j < match.length; j++) {
+                if (match[j]) {
+                    var starData = Utils.trim(match[j]);
+                    // Concepts are not allowed to be stars or captured input.
+                    starData = (starData[0] == "~") ? starData.substr(1) : starData;
+                    stars.push(starData);
+                }
+            }
+        }
+
+        var data = {stars: stars, trigger: trigger };
+        if (topic !== "reply") {
+            data.topic = topic;
+        }
+
+        matches.push(data);
+        cb(null, matches);
+    };
+
+    var _doesMatch = function(trigger, message, user, callback) {
+
+        var match = false;
+
+        regexreply.postParse(trigger.trigger, message, user, function complexFunction(regexp) {
+            var pattern = new RegExp("^" + regexp + "$", "i");
+
+            debug.verbose("Try to match (clean)'" + message.clean + "' against " + trigger.trigger + " (" + regexp + ")");
+            debug.verbose("Try to match (lemma)'" + message.lemString + "' against " + trigger.trigger + " (" + regexp + ")");
+
+            // Match on the question type (qtype / qsubtype)
+            if (trigger.isQuestion && message.isQuestion) {
+
+                if (_.isEmpty(trigger.qSubType) && _.isEmpty(trigger.qType) && message.isQuestion === true) {
+                    match = message.clean.match(pattern);
+                    if (!match) {
+                        match = message.lemString.match(pattern);
+                    }
+                } else {
+                    if ((!_.isEmpty(trigger.qType) && message.qtype.indexOf(trigger.qType) !== -1) ||
+                    message.qSubType === trigger.qSubType) {
+                        match = message.clean.match(pattern);
+                        if (!match) {
+                            match = message.lemString.match(pattern);
+                        }
+                    }
+                }
+            } else {
+                // This is a normal match
+                if (trigger.isQuestion === false) {
+                    match = message.clean.match(pattern);
+                    if (!match) {
+                        match = message.lemString.match(pattern);
+                    }
+                }
+            }
+
+            callback(null, match);
+        });
+    };
+
+    // This is the main function that looks for a matching entry
+        var _eachGambitHandle = function (options) {
+            var filterRegex = /\s*\^(\w+)\(([\w<>,\|\s]*)\)\s*/i;
+
+            return function (trigger, callback) {
+
+                var match = false;
+                var matches = [];
+
+                var message = options.message;
+                var user = options.user;
+                var plugins = options.plugins;
+                var scope = options.scope;
+                var topic = options.topic || "reply";
+
+                _doesMatch(trigger, message, user, function (err, match) {
+
+                    if (match) {
+                        if (trigger.filter !== "") {
+                            // We need scope and functions
+                            debug.verbose("We have a filter function", trigger.filter);
+
+                            var filterFunction = trigger.filter.match(filterRegex);
+                            debug.verbose("Filter Function Found", filterFunction);
+
+                            var pluginName = Utils.trim(filterFunction[1]);
+                            var partsStr = Utils.trim(filterFunction[2]);
+                            var parts = partsStr.split(",");
+
+                            var args = [];
+                            for (var i = 0; i < parts.length; i++) {
+                                if (parts[i] !== "") {
+                                    args.push(parts[i].trim());
+                                }
+                            }
+
+                            if (plugins[pluginName]) {
+
+                                var filterScope = scope;
+                                filterScope.message = options.localOptions.message;
+                                filterScope.message_props = options.localOptions.messageScope;
+                                filterScope.user = options.localOptions.user;
+
+                                args.push(function customFilterFunctionHandle(err, filterReply) {
+                                    if (err) {
+                                        console.log(err);
+                                    }
+
+                                    if (filterReply === "true" || filterReply === true) {
+                                        debug.verbose("filterReply", filterReply);
+
+                                        if (trigger.redirect !== "") {
+                                            debug.verbose("Found Redirect Match with topic " + topic);
+                                            getTopic().findTriggerByTrigger(trigger.redirect, function (err2, gambit) {
+                                                if (err2) {
+                                                    console.log(err2);
+                                                }
+
+                                                trigger = gambit;
+                                                callback(null, matches);
+                                            });
+
+                                        } else {
+                                            // Tag the message with the found Trigger we matched on
+                                            message.gambitId = trigger._id;
+                                            _afterHandle(match, matches, trigger, topic, callback);
+                                        }
+                                    } else {
+                                        debug.verbose("filterReply", filterReply);
+                                        callback(null, matches);
+                                    }
+                                });
+
+                                debug.verbose("Calling Plugin Function", pluginName);
+                                plugins[pluginName].apply(filterScope, args);
+
+                            } else {
+                                debug.verbose("Custom Filter Function not-found", pluginName);
+                                callback(null, matches);
+                            }
+                        } else {
+
+                            if (trigger.redirect !== "") {
+                                debug.verbose("Found Redirect Match with topic");
+                                getTopic().findTriggerByTrigger(trigger.redirect, function (err, gambit) {
+                                    if (err) {
+                                        console.log(err);
+                                    }
+
+                                    debug.verbose("Redirecting to New Gambit", gambit);
+                                    trigger = gambit;
+                                    // Tag the message with the found Trigger we matched on
+                                    message.gambitId = trigger._id;
+                                    _afterHandle(match, matches, trigger, topic, callback);
+                                });
+                            } else {
+                                // Tag the message with the found Trigger we matched on
+                                message.gambitId = trigger._id;
+                                _afterHandle(match, matches, trigger, topic, callback);
+                            }
+                        }
+                    } else {
+                        callback(null, matches);
                     }
 
-                    trigger = gambit;
-                    callback(null, matches);
-                  });
+                }); // end regexReply
+            }; // end EachGambit
+        };
 
-                } else {
-                  // Tag the message with the found Trigger we matched on
-                  message.gambitId = trigger._id;
-                  _afterHandle(match, matches, trigger, topic, callback);
-                }
-              } else {
-                debug.verbose("filterReply", filterReply);
-                callback(null, matches);
-              }
-            });
+        return {
+            walkReplyParent: function (repId, cb) {
+                _walkReplyParent(repId, [], cb);
+            }
+            , walkGambitParent: function (gambitId, cb) {
+                _walkGambitParent(gambitId, [], cb);
+            }
+            , eachGambit: eachGambit
+            , doesMatch: _doesMatch
+        };
 
-            debug.verbose("Calling Plugin Function", pluginName);
-            plugins[pluginName].apply(filterScope, args);
-
-          } else {
-            debug.verbose("Custom Filter Function not-found", pluginName);
-            callback(null, matches);
-          }
-        } else {
-
-          if (trigger.redirect !== "") {
-            debug.verbose("Found Redirect Match with topic");
-            Topic.findTriggerByTrigger(trigger.redirect, function (err, gambit) {
-              if (err) {
-                console.log(err);
-              }
-
-              debug.verbose("Redirecting to New Gambit", gambit);
-              trigger = gambit;
-              // Tag the message with the found Trigger we matched on
-              message.gambitId = trigger._id;
-              _afterHandle(match, matches, trigger, topic, callback);
-            });
-          } else {
-            // Tag the message with the found Trigger we matched on
-            message.gambitId = trigger._id;
-            _afterHandle(match, matches, trigger, topic, callback);
-          }
-        }
-      } else {
-        callback(null, matches);
-      }
-
-    }); // end regexReply
-  }; // end EachGambit
-};
+}; //end export

--- a/lib/topics/common.js
+++ b/lib/topics/common.js
@@ -7,11 +7,10 @@ var Utils = require("../utils");
 var _ = require("lodash");
 
 module.exports = function(mongoose) {
-    var getReply = function() { return mongoose.model('Reply'); }
-      , getGambit = function() { return mongoose.model('Gambit'); }
-      , getCondition = function() { return mongoose.model('Condition'); }
-      , getTopic = function() { return mongoose.model('Topic'); }
-    ;
+    var getReply = function() { return mongoose.model('Reply'); };
+    var getGambit = function() { return mongoose.model('Gambit'); };
+    var getCondition = function() { return mongoose.model('Condition'); };
+    var getTopic = function() { return mongoose.model('Topic'); };
 
     var _walkReplyParent = function (repId, replyIds, cb) {
         getReply().findById(repId)
@@ -283,12 +282,12 @@ module.exports = function(mongoose) {
         return {
             walkReplyParent: function (repId, cb) {
                 _walkReplyParent(repId, [], cb);
-            }
-            , walkGambitParent: function (gambitId, cb) {
+            },
+            walkGambitParent: function (gambitId, cb) {
                 _walkGambitParent(gambitId, [], cb);
-            }
-            , eachGambit: eachGambit
-            , doesMatch: _doesMatch
+            },
+            eachGambit: eachGambit,
+            doesMatch: _doesMatch
         };
 
 }; //end export

--- a/lib/topics/condition.js
+++ b/lib/topics/condition.js
@@ -1,4 +1,3 @@
-/*global Reply*/
 /**
 
   A Condition is a type of Gambit that contains a set of gambits, but instead 
@@ -6,9 +5,8 @@
 
 **/
 
-var Common = require("./common");
-
 module.exports = function (mongoose) {
+  var Common = require("./common")(mongoose);
   var Utils = require("../utils");
   var debug = require("debug-levels")("SS:Condition");
   var findOrCreate = require("mongoose-findorcreate");

--- a/lib/topics/gambit.js
+++ b/lib/topics/gambit.js
@@ -1,4 +1,3 @@
-/*global Reply*/
 /**
 
   A Gambit is a Trigger + Reply or Reply Set
@@ -15,7 +14,7 @@ module.exports = function (mongoose, facts) {
   var async = require("async");
   var norm = require("node-normalizer");
   var findOrCreate = require("mongoose-findorcreate");
-  var Common = require("./common");
+  var Common = require("./common")(mongoose);
   var gNormalizer;
 
   norm.loadData(function () {
@@ -90,7 +89,10 @@ module.exports = function (mongoose, facts) {
   });
 
   gambitSchema.methods.addReply = function (replyData, callback) {
-    var self = this;
+    var self  = this
+      , Reply = mongoose.model('Reply')
+    ;
+
     if (!replyData) {
       return callback("No data");
     }
@@ -112,7 +114,9 @@ module.exports = function (mongoose, facts) {
   };
 
   gambitSchema.methods.clearReplies = function (callback) {
-    var self = this;
+    var self = this
+      , Reply = mongoose.model('Reply')
+    ;
 
     var clearReply = function (replyId, cb) {
       self.replies.pull({ _id: replyId });
@@ -136,7 +140,9 @@ module.exports = function (mongoose, facts) {
 
 
   gambitSchema.methods.getRootTopic = function (cb) {
-    var self = this;
+    var self = this
+      , Topic = mongoose.model('Topic')
+    ;
     if (!self.parent) {
       Topic.findOne({ gambits: { $in: [ self._id ] } }).exec(function (err, doc) {
         cb(err, doc.name);

--- a/lib/topics/gambit.js
+++ b/lib/topics/gambit.js
@@ -89,9 +89,8 @@ module.exports = function (mongoose, facts) {
   });
 
   gambitSchema.methods.addReply = function (replyData, callback) {
-    var self  = this
-      , Reply = mongoose.model('Reply')
-    ;
+    var self  = this;
+    var Reply = mongoose.model('Reply');
 
     if (!replyData) {
       return callback("No data");
@@ -114,9 +113,8 @@ module.exports = function (mongoose, facts) {
   };
 
   gambitSchema.methods.clearReplies = function (callback) {
-    var self = this
-      , Reply = mongoose.model('Reply')
-    ;
+    var self = this;
+    var Reply = mongoose.model('Reply');
 
     var clearReply = function (replyId, cb) {
       self.replies.pull({ _id: replyId });
@@ -140,9 +138,9 @@ module.exports = function (mongoose, facts) {
 
 
   gambitSchema.methods.getRootTopic = function (cb) {
-    var self = this
-      , Topic = mongoose.model('Topic')
-    ;
+    var self = this;
+    var Topic = mongoose.model('Topic');
+
     if (!self.parent) {
       Topic.findOne({ gambits: { $in: [ self._id ] } }).exec(function (err, doc) {
         cb(err, doc.name);

--- a/lib/topics/import.js
+++ b/lib/topics/import.js
@@ -207,7 +207,7 @@ module.exports = function (factSystem, Topic, Gambit, Reply) {
               next();
             });
           });
-        }
+        };
 
         async.eachSeries(Object.keys(data.convos), convoItor, function() {
           debug.verbose("Add Conditions Added");

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -14,12 +14,11 @@
 **/
 
 module.exports = function (mongoose, factSystem) {
-  var Gambit    = require("./gambit")(mongoose, factSystem)
-    , Topic     = require("./topic")(mongoose)
-    , Condition = require("./condition")(mongoose)
-    , Reply     = require("./reply")(mongoose)
-    , Importer  = require("./import")(factSystem, Topic, Gambit, Reply)
-  ;
+  var Gambit    = require("./gambit")(mongoose, factSystem);
+  var Topic     = require("./topic")(mongoose);
+  var Condition = require("./condition")(mongoose);
+  var Reply     = require("./reply")(mongoose);
+  var Importer  = require("./import")(factSystem, Topic, Gambit, Reply);
 
   Gambit.count({}, function(err, gambits) {
     console.log("Number of Gambits:", gambits);

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -1,5 +1,3 @@
-/*global Reply, Topic, Gambit, Importer */
-/*eslint no-undef:0 */
 /**
   I want to create a more organic approch to authoring new gambits, topics and replies
   Right now, the system parses flat files to a intermediate JSON object that SS reads and
@@ -16,13 +14,12 @@
 **/
 
 module.exports = function (mongoose, factSystem) {
-
-  // Pushed to Global.
-  Gambit = require("./gambit")(mongoose, factSystem);
-  Topic = require("./topic")(mongoose);
-  Condition = require("./condition")(mongoose);
-  Reply = require("./reply")(mongoose);
-  Importer = require("./import")(factSystem, Topic, Gambit, Reply);
+  var Gambit    = require("./gambit")(mongoose, factSystem)
+    , Topic     = require("./topic")(mongoose)
+    , Condition = require("./condition")(mongoose)
+    , Reply     = require("./reply")(mongoose)
+    , Importer  = require("./import")(factSystem, Topic, Gambit, Reply)
+  ;
 
   Gambit.count({}, function(err, gambits) {
     console.log("Number of Gambits:", gambits);

--- a/lib/topics/reply.js
+++ b/lib/topics/reply.js
@@ -1,12 +1,11 @@
-/*globals Gambit */
 var Utils = require("../utils");
 var debug = require("debug")("Reply");
 var dwarn = require("debug")("Reply:Error");
 var Sort = require("./sort");
 var async = require("async");
-var Common = require("./common");
 
 module.exports = function (mongoose) {
+  var Common = require("./common")(mongoose);
 
   var replySchema = new mongoose.Schema({
     id: {type: String, index: true, default: Utils.genId()},
@@ -36,7 +35,9 @@ module.exports = function (mongoose) {
   };
 
   replySchema.methods.sortGambits = function (callback) {
-    var self = this;
+    var self = this
+      , Gambit = mongoose.model('Gambit')
+    ;
     var expandReorder = function (gambitId, cb) {
       Gambit.findById(gambitId, function (err, gambit) {
         cb(err, gambit);

--- a/lib/topics/topic.js
+++ b/lib/topics/topic.js
@@ -47,10 +47,9 @@ module.exports = function (mongoose) {
   });
 
   topicSchema.methods.createCondition = function(conditionData, callback) {
-    var self = this
-      , Gambit = mongoose.model('Gambit')
-      , Condition = mongoose.model('Condition')
-    ;
+    var self = this;
+    var Gambit = mongoose.model('Gambit');
+    var Condition = mongoose.model('Condition');
 
     if (!conditionData) {
       return callback("No data");
@@ -107,9 +106,8 @@ module.exports = function (mongoose) {
   };
 
   topicSchema.methods.sortGambits = function (callback) {
-    var self = this
-      , Gambit = mongoose.model('Gambit')
-    ;
+    var self = this;
+    var Gambit = mongoose.model('Gambit');
 
     var expandReorder = function (gambitId, cb) {
       Gambit.findById(gambitId, function (err, gambit) {
@@ -194,9 +192,8 @@ module.exports = function (mongoose) {
   // Lightweight match for one topic
   // TODO offload this to common
   topicSchema.methods.doesMatch = function (message, cb) {
-    var self = this
-      , Topic = mongoose.model('Topic')
-    ;
+    var self = this;
+    var Topic = mongoose.model('Topic');
 
     var itor = function (gambit, next) {
       gambit.doesMatch(message, function (err, match2) {
@@ -221,9 +218,8 @@ module.exports = function (mongoose) {
   };
 
   topicSchema.methods.clearGambits = function (callback) {
-    var self = this
-      , Gambit = mongoose.model('Gambit')
-    ;
+    var self = this;
+    var Gambit = mongoose.model('Gambit');
 
     var clearGambit = function (gambitId, cb) {
       self.gambits.pull({ _id: gambitId });

--- a/lib/topics/topic.js
+++ b/lib/topics/topic.js
@@ -1,6 +1,6 @@
-/*global Reply, Topic, Gambit */
+/*global _walkParent */
 /**
-
+  TODO Where is walkParent defined? 
   Topics are a grouping of gambits.
   The order of the Gambits are important, and a gambit can live in more than one topic.
 
@@ -12,13 +12,13 @@ var async = require("async");
 var findOrCreate = require("mongoose-findorcreate");
 var debug = require("debug-levels")("SS:Topics");
 var Sort = require("./sort");
-var Common = require("./common");
 var safeEval = require("safe-eval");
 
 var TfIdf = natural.TfIdf;
 var tfidf = new TfIdf();
 
 module.exports = function (mongoose) {
+  var Common = require("./common")(mongoose);
 
   natural.PorterStemmer.attach();
 
@@ -47,7 +47,11 @@ module.exports = function (mongoose) {
   });
 
   topicSchema.methods.createCondition = function(conditionData, callback) {
-    var self = this;
+    var self = this
+      , Gambit = mongoose.model('Gambit')
+      , Condition = mongoose.model('Condition')
+    ;
+
     if (!conditionData) {
       return callback("No data");
     }
@@ -77,12 +81,14 @@ module.exports = function (mongoose) {
             callback(err2, condition);
           });
         });        
-      })
+      });
     }
   };
 
   // This will create the Gambit and add it to the model
   topicSchema.methods.createGambit = function (gambitData, callback) {
+    var Gambit = mongoose.model('Gambit');
+
     if (!gambitData) {
       return callback("No data");
     }
@@ -101,7 +107,10 @@ module.exports = function (mongoose) {
   };
 
   topicSchema.methods.sortGambits = function (callback) {
-    var self = this;
+    var self = this
+      , Gambit = mongoose.model('Gambit')
+    ;
+
     var expandReorder = function (gambitId, cb) {
       Gambit.findById(gambitId, function (err, gambit) {
         if (err) {
@@ -185,7 +194,9 @@ module.exports = function (mongoose) {
   // Lightweight match for one topic
   // TODO offload this to common
   topicSchema.methods.doesMatch = function (message, cb) {
-    var self = this;
+    var self = this
+      , Topic = mongoose.model('Topic')
+    ;
 
     var itor = function (gambit, next) {
       gambit.doesMatch(message, function (err, match2) {
@@ -210,7 +221,9 @@ module.exports = function (mongoose) {
   };
 
   topicSchema.methods.clearGambits = function (callback) {
-    var self = this;
+    var self = this
+      , Gambit = mongoose.model('Gambit')
+    ;
 
     var clearGambit = function (gambitId, cb) {
       self.gambits.pull({ _id: gambitId });
@@ -242,6 +255,7 @@ module.exports = function (mongoose) {
 
   // This will find a gambit in any topic
   topicSchema.statics.findTriggerByTrigger = function (input, callback) {
+    var Gambit = mongoose.model('Gambit');
     Gambit.findOne({input: input}).exec(callback);
   };
 
@@ -284,11 +298,11 @@ module.exports = function (mongoose) {
 
 
   topicSchema.statics.findPendingTopicsForUser = function (user, msg, callback) {
-
     var self = this;
     var currentTopic = user.getTopic();
     var aTopics = [];
     var i;
+    var Reply = mongoose.model('Reply');
 
     var scoredTopics = _score(msg);
     debug.verbose("Topic Score", scoredTopics);
@@ -340,7 +354,7 @@ module.exports = function (mongoose) {
       aTopics.push({name: "__post__", type:"TOPIC"});
 
       // Lets assign the ids to the topics
-      for (var i = 0; i < aTopics.length; i++) {
+      for (i = 0; i < aTopics.length; i++) {
         var tName = aTopics[i].name;
         for (var n = 0; n < allTopics.length; n++) {
           if (allTopics[n].name === tName) {

--- a/lib/users.js
+++ b/lib/users.js
@@ -74,7 +74,7 @@ var UX = function (mongoose, sfacts) {
       matched_gambit: replyObj.minMatchSet,
       final_output: reply.clean,
       timestamp: msg.createdAt
-    }
+    };
     
     fs.appendFileSync(process.cwd() + "/logs/" + this.id + "_trans.txt", JSON.stringify(log) + "\r\n");
 
@@ -104,7 +104,7 @@ var UX = function (mongoose, sfacts) {
       var pt = self.pendingTopic;
       self.pendingTopic = null;
 
-      Topic.findOne({name:pt}, function(err, topicData) {
+      mongoose.model('Topic').findOne({name:pt}, function(err, topicData) {
         if (topicData && topicData.nostay === true) {
           self.currentTopic = self.__history__.topic[0];
         } else {

--- a/test/capture.js
+++ b/test/capture.js
@@ -1,3 +1,4 @@
+/*global describe, it, bot, before, after */
 var mocha = require("mocha");
 var should  = require("should");
 var help = require("./helpers");


### PR DESCRIPTION
## Description
- Removes the models from the global scope so that multiple mongoose connections (to different dbs) can work / don't clobber eachother.
- Small jslint fixes (semicolons and such)
- Use `mergex` directly in tests (that function was accidentally removed previously)

## Motivation and Context
If you are supporting multiple bots on the same backend, but attached to different databases, the previous version would fail.

## How Has This Been Tested?
Ran `npm test` - some failures, but I seemingly unrelated to my changes. 

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Other Notes: 
The diff for `lib/topics/common.js` seems horrendous, but all that really happens is wrapping the file in a function so that it can be associated with different mongoose connections (similar to the other topic files). 

