### PR TITLE
Quick change to prevent log writing errors on windows

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -81,7 +81,8 @@ var UX = function (mongoose, sfacts) {
       timestamp: msg.createdAt
     };
     
-    fs.appendFileSync(process.cwd() + "/logs/" + this.id + "_trans.txt", JSON.stringify(log) + "\r\n");
+    var cleanId = id.replace(/\W/g, '');
+    fs.appendFileSync(process.cwd() + "/logs/" + cleanId + "_trans.txt", JSON.stringify(log) + "\r\n");
 
     // Did we successfully volley?
     // In order to keep the conversation flowing we need to have rythum and this means we always


### PR DESCRIPTION
Running superscript on Windows (using bash on windows) I had an error with the telnet client where the filename includes colons, which are not allowed on Windows.
