### PR TITLE
update mongoose

### DIFF
--- a/bin/bot-init.js
+++ b/bin/bot-init.js
@@ -58,7 +58,7 @@ fs.mkdir(botPath, function(err, res){
     , dependencies: {
        'superscript': 'latest'
       , 'sfacts':'latest'
-      , 'mongoose':'3.8.24'
+      , 'mongoose':'4.5.10'
       ,'debug': '~2.0.0'
     }
   }


### PR DESCRIPTION
Need to update mongoose version in bot-init.js file to to generate bot with right dependence.
After running node.server from generated bot folder I had error 
`Error : Cannot find module '../build/Release/bson'] code: 'MODULE_NOT_FOUND' }`

I solved it just by installing the latest version of Mongoose. Tried to putt this in your package.json
mongoose': '4.5.10' & it helped :)
