### PR TITLE
Checkout chat history data with a property in options

### DIFF
--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -182,6 +182,7 @@ class SuperScriptInstance {
     // This is a kill switch for filterBySeen which is useless in the editor.
     this.editMode = options.editMode || false;
     this.conversationTimeout = options.conversationTimeout;
+    this.historyCheckpoints = options.historyCheckpoints;
     this.scope = options.scope || {};
 
     // Built-in plugins
@@ -224,6 +225,7 @@ class SuperScriptInstance {
       this.scope,
       this.editMode,
       this.conversationTimeout,
+      this.historyCheckpoints,
       tenantId,
     );
   }

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -14,7 +14,7 @@ import Logger from './logger';
 const debug = debuglog('SS:SuperScript');
 
 class SuperScript {
-  constructor(coreChatSystem, coreFactSystem, plugins, scope, editMode, conversationTimeout, tenantId = 'master') {
+  constructor(coreChatSystem, coreFactSystem, plugins, scope, editMode, conversationTimeout, historyCheckpoints, tenantId = 'master') {
     this.chatSystem = coreChatSystem.getChatSystem(tenantId);
     this.factSystem = coreFactSystem.getFactSystem(tenantId);
 
@@ -30,6 +30,7 @@ class SuperScript {
     this.plugins = plugins;
     this.editMode = editMode;
     this.conversationTimeout = conversationTimeout;
+    this.historyCheckpoints = historyCheckpoints;
   }
 
   importFile(filePath, callback) {
@@ -46,7 +47,7 @@ class SuperScript {
 
   getUser(userId, callback) {
     this.chatSystem.User.findOne({ id: userId })
-      .slice('history', 10)
+      .slice('history', this.historyCheckpoints)
       .exec(callback);
   }
 
@@ -55,7 +56,7 @@ class SuperScript {
       upsert: true,
       setDefaultsOnInsert: true,
       new: true,
-    }).slice('history', 10)
+    }).slice('history', this.historyCheckpoints)
       .exec(callback);
   }
 
@@ -242,6 +243,7 @@ const defaultOptions = {
   logPath: `${process.cwd()}/logs`,
   useMultitenancy: false,
   conversationTimeout: 1000 * 300,
+  historyCheckpoints: 10
 };
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Sometimes, developer would want the bot loop more chat history for none-keep topics. Currently, superscript only check out 10 messages in history. In our condition, we would like the bot can check out 100 messages or more in history.

## Description
<!--- Describe your changes in detail -->
Add a property in options - historyCheckpoints. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In our condition, the bot would ask many different questions randomly with a gambit.


* One user scenario 
```
+ _QUESTIONS
- foo1
- foo2 
- foo3
- foo4
- foo5
- foo6
- foo7
- foo8
- foo9
- foo10 
- foo11
```

If the bot just load 10 dialogues in history, some question would not be sent because the bot would ask some question repeatedly. 

In a word, the *question* would come back after 9 rounds.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
