### PR TITLE
Limits Importer to removing Topic, Reply, Gambit data. Refs: #366

### DIFF
--- a/src/bot/db/import.js
+++ b/src/bot/db/import.js
@@ -47,7 +47,6 @@ const importData = function importData(chatSystem, data, callback) {
   const Topic = chatSystem.Topic;
   const Gambit = chatSystem.Gambit;
   const Reply = chatSystem.Reply;
-  const User = chatSystem.User;
 
   const gambitsWithConversation = [];
 
@@ -162,7 +161,7 @@ const importData = function importData(chatSystem, data, callback) {
   debug.info('Cleaning database: removing all data.');
 
   // Remove everything before we start importing
-  async.each([Gambit, Reply, Topic, User],
+  async.each([Gambit, Reply, Topic],
     (model, nextModel) => {
       model.remove({}, err => nextModel());
     },


### PR DESCRIPTION
## Description
As per #366, ImportData was removing users every time it was re-importing the scripts. As there is no need to do so and it could create catastrophic data loss in production scenarios, I've simply removed 'Users' from the removal process. 

## Motivation and Context
I also investigated the possibility of adding a 'collectionsToRemove' array in cleanup that could then inform the ImportData function, but didn't have a use case that warranted it.

## How Has This Been Tested?
Poses no issues locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.