### PR TITLE
Add importJSON to setup options for support JSON

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,17 +1,18 @@
 ### 1.1.3
 
 * No longer removes `User` table on re-importing a bot script into MongoDB.
+* disable versioning in mongoDB,improved performance.
 
 ### 1.1.2
 
 * Fixes an issue with doing conversations with multiline replies.
-
-### 1.1.1
+* 
+### 1.1.1
 
 * Fixes a warning using the `moment` dependency.
 * Additional error message for errors within custom functions.
 
-### 1.1.0
+### 1.1.0
 
 * You can now configure the number of messages in the history that are checked when seeing if replies should be exhausted or not by using the `historyCheckpoints` option (thanks @Samurais!).
 
@@ -21,7 +22,7 @@
 * Cleanup and parse bin scripts now accept a MONGODB_URI environment variable for easy cleanup/parsing on Heroku.
 * Parse bin script also now accepts custom MongoDB connection params.
 
-### 1.0.5
+### 1.0.5
 
 * The history field on the User model now retains 500 messages (up from 15) for logging purposes. It also is now an array of objects, rather than being an object of arrays, so we can more easily iterate over the history, and allows us to slice the array easily.
 * Removed mongoose-findorcreate and replaced with native mongoose options `upsert` and `new`.

--- a/src/bot/db/models/user.js
+++ b/src/bot/db/models/user.js
@@ -23,6 +23,8 @@ const createUserModel = function createUserModel(db, factSystem, logger) {
     }],
   });
 
+  userSchema.set('versionKey', false);
+
   userSchema.pre('save', function (next) {
     debug.verbose('Pre-Save Hook');
     // save a full log of user conversations, but just in case a user has a
@@ -100,7 +102,7 @@ const createUserModel = function createUserModel(db, factSystem, logger) {
         } else {
           this.currentTopic = pendingTopic;
         }
-        this.save((err) => {
+        this.save(function(err){
           if (err) {
             console.error(err);
           }

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -41,6 +41,17 @@ class SuperScript {
     });
   }
 
+  importJSON(obj, callback) {
+    if (typeof obj === 'string') {
+      try {
+        obj = JSON.parse(obj);
+      } catch (error) {
+        callback(err); 
+      }
+    }
+    Importer.importData(this.chatSystem, obj, callback);
+  }
+
   getUsers(callback) {
     this.chatSystem.User.find({}, 'id', callback);
   }
@@ -233,6 +244,7 @@ class SuperScriptInstance {
 
 const defaultOptions = {
   mongoURI: 'mongodb://localhost/superscriptDB',
+  importJSON: null,
   importFile: null,
   factSystem: {
     clean: false,
@@ -253,6 +265,8 @@ const defaultOptions = {
  * @param {Object} options - Any configuration settings you want to use.
  * @param {String} options.mongoURI - The database URL you want to connect to.
  *                 This will be used for both the chat and fact system.
+ * @param {Object} options.importJSON - Use this if you want to re-import from JSON Object. 
+ *                 Otherwise SuperScript will use whatever it currently finds in the database.
  * @param {String} options.importFile - Use this if you want to re-import your parsed
  *                 '*.json' file. Otherwise SuperScript will use whatever it currently
  *                 finds in the database.
@@ -302,6 +316,9 @@ const setup = function setup(options = {}, callback) {
     const bot = instance.getBot('master');
     if (options.importFile) {
       return bot.importFile(options.importFile, err => callback(err, bot));
+    }
+    if (options.importJSON) {
+      return bot.importJSON(options.importJSON, err => callback(err, bot));
     }
     return callback(null, bot);
   });

--- a/test/script.js
+++ b/test/script.js
@@ -224,7 +224,7 @@ describe('SuperScript Scripting + Style Interface', () => {
     });
 
     // This will require processing function tags before any other reply tags
-    it.skip('Change topic 2', (done) => {
+    it('Change topic 2', (done) => {
       helpers.getBot().reply('user4', 'reply with a new topic from function', (err, reply) => {
         helpers.getBot().getUser('user4', (err, user) => {
           should(user.currentTopic).eql('fish');


### PR DESCRIPTION
 Changes to be committed:
	modified:   src/bot/index.js

## Description
Can I import only JSON, not a file ?

## Motivation and Context
I want to use JSON object more than file in setup bot


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
