### PR TITLE
Allow for optional cleaning during parse. Defaults now to false.

### DIFF
--- a/src/bin/parse.js
+++ b/src/bin/parse.js
@@ -10,6 +10,7 @@ program
   .option('-p, --path [type]', 'Input path', './chat')
   .option('-o, --output [type]', 'Output options', 'data.json')
   .option('-f, --force [type]', 'Force save if output file already exists', false)
+  .option('-c, --clean [type]', 'Clean -> drops the mongodown collection', false)
   .option('-F, --facts [type]', 'Fact system files path', files => files.split(','), [])
   .option('--host [type]', 'Mongo Host', 'localhost')
   .option('--port [type]', 'Mongo Port', '27017')
@@ -28,7 +29,7 @@ fs.exists(program.output, (exists) => {
     return process.exit();
   }
 
-  return facts.load(mongoURI, program.facts, true, (err, factSystem) => {
+  return facts.load(mongoURI, program.facts, program.clean, (err, factSystem) => {
     parser.parseDirectory(program.path, { factSystem }, (err, result) => {
       if (err) {
         console.error(`Error parsing bot script: ${err}`);


### PR DESCRIPTION
In parse, allows -c flag to indicate desire to clean db during parse.  Set default to false.

## Description
Fix for #373 

## Motivation and Context
Protect the data!

## How Has This Been Tested?
Would love someone else to test in their environment.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) (only if someone for some reason would actually be expecting parse to blow out their entire db)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.