### PR TITLE
I think in directReply should have extraScope too

### DIFF
--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -41,6 +41,17 @@ class SuperScript {
     });
   }
 
+  importJSON(obj, callback) {
+    if (typeof obj === 'string') {
+      try {
+        obj = JSON.parse(obj);
+      } catch (error) {
+        callback(err); 
+      }
+    }
+    Importer.importData(this.chatSystem, obj, callback);
+  }
+
   getUsers(callback) {
     this.chatSystem.User.find({}, 'id', callback);
   }
@@ -233,6 +244,7 @@ class SuperScriptInstance {
 
 const defaultOptions = {
   mongoURI: 'mongodb://localhost/superscriptDB',
+  importJSON: null,
   importFile: null,
   factSystem: {
     clean: false,
@@ -253,6 +265,8 @@ const defaultOptions = {
  * @param {Object} options - Any configuration settings you want to use.
  * @param {String} options.mongoURI - The database URL you want to connect to.
  *                 This will be used for both the chat and fact system.
+ * @param {Object} options.importJSON - Use this if you want to re-import from JSON Object. 
+ *                 Otherwise SuperScript will use whatever it currently finds in the database.
  * @param {String} options.importFile - Use this if you want to re-import your parsed
  *                 '*.json' file. Otherwise SuperScript will use whatever it currently
  *                 finds in the database.
@@ -302,6 +316,9 @@ const setup = function setup(options = {}, callback) {
     const bot = instance.getBot('master');
     if (options.importFile) {
       return bot.importFile(options.importFile, err => callback(err, bot));
+    }
+    if (options.importJSON) {
+      return bot.importJSON(options.importJSON, err => callback(err, bot));
     }
     return callback(null, bot);
   });

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -91,12 +91,12 @@ class SuperScript {
   }
 
   // This is like doing a topicRedirect
-  directReply(userId, topicName, messageString, callback) {
+  directReply(userId, topicName, messageString, callback, extraScope) {
     debug.log("[ New DirectReply - '%s']- %s", userId, messageString);
     const options = {
       userId,
       topicName,
-      extraScope: {},
+      extraScope: extraScope || {},
     };
 
     this._reply(messageString, options, callback);

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -41,17 +41,6 @@ class SuperScript {
     });
   }
 
-  importJSON(obj, callback) {
-    if (typeof obj === 'string') {
-      try {
-        obj = JSON.parse(obj);
-      } catch (error) {
-        callback(err); 
-      }
-    }
-    Importer.importData(this.chatSystem, obj, callback);
-  }
-
   getUsers(callback) {
     this.chatSystem.User.find({}, 'id', callback);
   }
@@ -244,7 +233,6 @@ class SuperScriptInstance {
 
 const defaultOptions = {
   mongoURI: 'mongodb://localhost/superscriptDB',
-  importJSON: null,
   importFile: null,
   factSystem: {
     clean: false,
@@ -265,8 +253,6 @@ const defaultOptions = {
  * @param {Object} options - Any configuration settings you want to use.
  * @param {String} options.mongoURI - The database URL you want to connect to.
  *                 This will be used for both the chat and fact system.
- * @param {Object} options.importJSON - Use this if you want to re-import from JSON Object. 
- *                 Otherwise SuperScript will use whatever it currently finds in the database.
  * @param {String} options.importFile - Use this if you want to re-import your parsed
  *                 '*.json' file. Otherwise SuperScript will use whatever it currently
  *                 finds in the database.
@@ -316,9 +302,6 @@ const setup = function setup(options = {}, callback) {
     const bot = instance.getBot('master');
     if (options.importFile) {
       return bot.importFile(options.importFile, err => callback(err, bot));
-    }
-    if (options.importJSON) {
-      return bot.importJSON(options.importJSON, err => callback(err, bot));
     }
     return callback(null, bot);
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
add extraScope on directReply function via 4th parameter
in reply function have it but in directReply that like do the same not have it.
## Description
add extraScope on directReply function via 4th parameter
in reply function have it but in directReply that like do the same not have it.

## Motivation and Context
I want to use extraScope when call directReply()
## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
