### PR TITLE
Make extraScope can access in trigger rules

### DIFF
--- a/src/bot/getReply/helpers.js
+++ b/src/bot/getReply/helpers.js
@@ -153,7 +153,7 @@ const eachGambitHandle = async function eachGambitHandle(gambit, message, option
     // the current reply.
     const filterScope = _.merge({}, scope);
     filterScope.message = message;
-    // filterScope.message_props = options.localOptions.messageScope;
+    filterScope.message_props = options.system.extraScope;
     filterScope.user = options.user;
 
     let filterReply;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
uncommnet line:156 in helpers.js that make extraScope cannot use in trigger rules
use options.system.extraScope instead of old one
## Description
<!--- Describe your changes in detail -->
uncommnet line:156 in helpers.js that make extraScope cannot use in trigger rules
use options.system.extraScope instead of old one

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I want to use extraScope in trigger rules and found this commented code here
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
