### PR TITLE
Resolving issue #375. During conversation the match should retain topic

### DIFF
--- a/src/bot/db/import.js
+++ b/src/bot/db/import.js
@@ -21,6 +21,7 @@ const rawToGambitData = function rawToGambitData(gambitId, gambit) {
     filter: gambit.trigger.filter,
     trigger: gambit.trigger.clean,
     input: gambit.trigger.raw,
+    topic: gambit.topic
   };
 
   // Conditional rolled up triggers will not have a flags

--- a/src/bot/db/models/gambit.js
+++ b/src/bot/db/models/gambit.js
@@ -57,6 +57,9 @@ const createGambitModel = function createGambitModel(db, factSystem) {
     // TODO, change the type to a ID and reference another gambit directly
     // this will save us a lookup down the road (and improve performace.)
     redirect: { type: String, default: '' },
+
+    // topic field added to fix issue#375
+    topic: { type: String, default: 'random'}
   });
 
   gambitSchema.pre('save', function (next) {

--- a/src/bot/getReply/index.js
+++ b/src/bot/getReply/index.js
@@ -72,6 +72,18 @@ const findMatches = async function findMatches(pendingTopics, messageObject, opt
       debug.info(`Replies: ${match.gambit.replies.map(reply => reply.reply).join('\n')}`);
     });
 
+    // If there are multiple matches, then select the one from topic. Issue #375  
+    function isTopicMatched(match) {
+      return match.gambit.topic === options.user.getTopic();
+    }
+    var topicIndex = unfilteredMatches.findIndex(isTopicMatched);
+
+    if (unfilteredMatches.length > 1 && topicIndex > 0) {
+      var tmp = unfilteredMatches[0];
+      unfilteredMatches[0] = unfilteredMatches[topicIndex];
+      unfilteredMatches[topicIndex] = tmp;
+    }
+
     for (let j = 0; j < unfilteredMatches.length && !stopSearching; ++j) {
       const match = unfilteredMatches[j];
       const reply = await matchItorHandle(match, messageObject, options);


### PR DESCRIPTION
During conversation the match should retain topic

## Description
When the topic is switched, and the first gambit is a conversation, it always matches the first topic, rather than switched topic. For more detail refer https://github.com/superscriptjs/superscript/issues/375

## Motivation and Context
When there are multiple topics with same request gambit, we get multiple replies. The reply inside the current topic should be selected, rather than the first one in replies array. The fix is to move the reply in current topic to beginning of the array.

https://github.com/superscriptjs/superscript/issues/375

## How Has This Been Tested?
The code is tested with existing test cases. All test cases pass.

For the expected behavior, tested with the scenario given in issue #375 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
